### PR TITLE
Feature/remove kernel postinst

### DIFF
--- a/configs/etc/kernel/postinst.d/zImage-uboot
+++ b/configs/etc/kernel/postinst.d/zImage-uboot
@@ -1,2 +1,0 @@
-#!/bin/sh
-ln -s -f $2 /boot/zImage

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (1.73) stable; urgency=medium
+
+  * Move out kernel postinst hook to linux-image-$FLAVOUR metapackage
+
+ -- Alexey Ignatov <lexszero@gmail.com>  Mon, 10 Apr 2017 03:07:05 +0300
+
 wb-configs (1.72.1) stable; urgency=medium
 
   * ttyAPP0 => ttyGSM in configs

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Homepage: <insert the upstream URL, if relevant>
 
 Package: wb-configs
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, ucf, wb-utils (>= 1.71), inotify-tools, mosquitto (>= 1.4.7-1), watchdog (>= 5.15)
+Depends: ${shlibs:Depends}, ${misc:Depends}, ucf, wb-utils (>= 1.71), inotify-tools, mosquitto (>= 1.4.7-1), watchdog (>= 5.15), linux-image-wb
 Provides: ${diverted-files}, mqtt-wss
 Conflicts: ${diverted-files}, mqtt-wss
 Replaces: mqtt-wss

--- a/debian/wb-configs.maintscript
+++ b/debian/wb-configs.maintscript
@@ -1,0 +1,1 @@
+rm_conffile /etc/kernel/postinst.d/zImage-uboot


### PR DESCRIPTION
Moved to linux-image-<flavour> metapackage (v4.9.x)