### PR TITLE
Fix sshd diversion clash on upgrade from wb-configs < 1.75.4

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (1.77.1) stable; urgency=medium
+
+  * Fix: manually undisplace sshd_config from older wb-configs
+
+ -- Nikita Maslov <n.maslov@contactless.ru>  Fri, 29 Jun 2018 12:37:15 +0300
+
 wb-configs (1.77) stable; urgency=medium
 
   * Fix dependencies between wb-configs and wb-configs-<releasename>

--- a/debian/control
+++ b/debian/control
@@ -17,13 +17,17 @@ Description: Default common config files for Wiren Board
 Package: wb-configs-wheezy
 Architecture: all
 Depends: sysvinit (>= 2.88), lsb-base (>= 4.1)
-Replaces: wb-configs-stretch
+Provides: ${diverted-files}
+Conflicts: ${diverted-files}
+Replaces: wb-configs-stretch, wb-configs (<< 1.77)
 Breaks: wb-configs (<< 1.77)
 Description: Default wheezy-specific config files for Wiren Board
 
 Package: wb-configs-stretch
 Architecture: all
 Depends: systemd (>= 232-25)
-Replaces: wb-configs-wheezy
+Provides: ${diverted-files}
+Conflicts: ${diverted-files}
+Replaces: wb-configs-wheezy, wb-configs (<< 1.77)
 Breaks: wb-configs (<< 1.77)
 Description: Default stretch-specific config files for Wiren Board

--- a/debian/wb-configs-stretch.postinst
+++ b/debian/wb-configs-stretch.postinst
@@ -1,0 +1,74 @@
+#!/bin/bash
+set -e
+
+ours=.wb
+theirs=.wb-orig
+
+# Remove diversion of sshd_configs from wb-configs which
+# was accidently left unattended
+
+# These functions are taken from config-package-dev heplers
+# with modifications which allow to remove diversions from
+# other packages
+wb_undisplace_unlink_symlink()
+{
+    file="$1"
+    ourfile="$2"
+    theirfile="$3"
+    if [ ! -L "$file" ] || \
+	[ "$(readlink "$file")" != "$(basename "$ourfile")" -a \
+	  "$(readlink "$file")" != "$(basename "$theirfile")" ]; then
+	echo "*** OMINOUS WARNING ***: $file is not linked to either $(basename "$ourfile") or $(basename "$theirfile")" >&2
+    else
+	rm -f "$file"
+    fi
+}
+
+wb_undisplace_unlink_displace()
+{
+    file="$1"
+    if [ ! -L "$file" ] && [ ! -e "$file" ]; then
+    echo "Run dpkg-divert --remove..."
+	dpkg-divert --remove --rename "$file"
+    else
+	echo "Not removing diversion of $file by $package" >&2
+    fi
+}
+
+wb_undisplace_unlink()
+{
+    prefix=$1
+    suffix=$2
+
+    file=$prefix$suffix
+    ourfile=$prefix$ours$suffix
+    theirfile=$prefix$theirs$suffix
+
+    wb_undisplace_unlink_symlink "$file" "$ourfile" "$theirfile"
+    wb_undisplace_unlink_displace "$file"
+}
+
+wb_check_undisplace_unlink_from()
+{
+    prefix=$1
+    suffix=$2
+    from_package=$3
+    from_version=$4
+
+    file=$prefix$suffix
+    ourfile=$prefix$ours$suffix
+    theirfile=$prefix$theirs$suffix
+
+    if LC_ALL=C dpkg-divert --list "$from_package" | \
+	grep -xFq "diversion of $file to $theirfile by $from_package" &&
+    dpkg --compare-versions `dpkg-query -f '${Version}' -W "$from_package"` "lt" "$from_version"; then
+        echo "Picking up diversion of $file from $package to replace it with our one"
+	    wb_undisplace_unlink "$prefix" "$suffix" "$from_package"
+    fi
+}
+
+if [ "$1" = "configure" ]; then
+    wb_check_undisplace_unlink_from /etc/ssh/sshd_config "" wb-configs "1.75.4"
+fi
+
+#DEBHELPER#

--- a/debian/wb-configs.postinst
+++ b/debian/wb-configs.postinst
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 . /etc/wb_env.sh
 
 #DEBHELPER#

--- a/debian/wb-configs.preinst
+++ b/debian/wb-configs.preinst
@@ -1,0 +1,73 @@
+#!/bin/bash
+set -e
+
+ours=.wb
+theirs=.wb-orig
+
+# Remove diversion of sshd_configs from wb-configs which
+# was accidently left unattended
+
+# These functions are taken from config-package-dev heplers
+# with modifications which allow to remove diversions from
+# other packages
+wb_undisplace_unlink_symlink()
+{
+    file="$1"
+    ourfile="$2"
+    theirfile="$3"
+    if [ ! -L "$file" ] || \
+	[ "$(readlink "$file")" != "$(basename "$ourfile")" -a \
+	  "$(readlink "$file")" != "$(basename "$theirfile")" ]; then
+	echo "*** OMINOUS WARNING ***: $file is not linked to either $(basename "$ourfile") or $(basename "$theirfile")" >&2
+    else
+	rm -f "$file"
+    fi
+}
+
+wb_undisplace_unlink_displace()
+{
+    file="$1"
+    if [ ! -L "$file" ] && [ ! -e "$file" ]; then
+    echo "Run dpkg-divert --remove..."
+	dpkg-divert --remove --rename "$file"
+    else
+	echo "Not removing diversion of $file by $package" >&2
+    fi
+}
+
+wb_undisplace_unlink()
+{
+    prefix=$1
+    suffix=$2
+
+    file=$prefix$suffix
+    ourfile=$prefix$ours$suffix
+    theirfile=$prefix$theirs$suffix
+
+    wb_undisplace_unlink_symlink "$file" "$ourfile" "$theirfile"
+    wb_undisplace_unlink_displace "$file"
+}
+
+wb_check_undisplace_unlink_from()
+{
+    prefix=$1
+    suffix=$2
+    from_package=$3
+    from_version=$4
+
+    file=$prefix$suffix
+    ourfile=$prefix$ours$suffix
+    theirfile=$prefix$theirs$suffix
+
+    if LC_ALL=C dpkg-divert --list "$from_package" | \
+	grep -xFq "diversion of $file to $theirfile by $from_package"; then
+        echo "Picking up diversion of $file from $package to replace it with our one"
+	    wb_undisplace_unlink "$prefix" "$suffix" "$from_package"
+    fi
+}
+
+if [ "$1" = "upgrade" ] && dpkg --compare-versions "$2" "lt" "1.75.4"; then
+    wb_check_undisplace_unlink_from /etc/ssh/sshd_config "" wb-configs "1.75.4"
+fi
+
+#DEBHELPER#

--- a/debian/wb-configs.undisplace
+++ b/debian/wb-configs.undisplace
@@ -1,0 +1,1 @@
+/etc/ssh/sshd_config.wb


### PR DESCRIPTION
An error caused by moving ssh configuration from wb-configs to wb-configs-stretch without preparation scripts. It breaks update from wb-configs < 1.75.4.

Now we need to use some magic copied from config-package-dev helpers to remove diversion of ssh config from wb-configs < 1.75.4 before configuring wb-configs-stretch. It is done both in preinst of wb-configs and postinst wb-configs-stretch just in case. The update procedure preserves user changed configuration.

Tested upgrade from 1.75.3 (with original and user modified configs) and from 1.77 (ignores procedure).