### PR TITLE
Post install scipt fails on WB5

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (1.79.1) stable; urgency=medium
+
+  * fix post install script fail on WB5
+
+ -- Evgeny Boger <boger@contactless.ru>  Wed, 06 Feb 2019 17:21:40 +0300
+
 wb-configs (1.79) stable; urgency=medium
 
   * u-boot env config for fw_setenv is moved to wb-configs from u-boot-tools.

--- a/debian/wb-configs.postinst
+++ b/debian/wb-configs.postinst
@@ -7,7 +7,7 @@ UBOOT_DIR="/usr/share/wb-configs/u-boot"
 UBOOT_FNAME="fw_env.config.wb"
 if of_machine_match "fsl,imx6ul" || of_machine_match "fsl,imx6ull"; then
     FVER="imx6"
-elif FVER "fsl,imx28" || of_machine_match "fsl,imx23"; then
+elif of_machine_match "fsl,imx28" || of_machine_match "fsl,imx23"; then
     FVER="mxs"
 else
     UBOOT_FNAME="default"


### PR DESCRIPTION
Error in 'journalctl' before change:
Feb 04 23:20:30 wb wb-init[2454]: Starting board-specific initscript: wb-initCannot parse config file '/etc/fw_env.config': No such file or directory
Feb 04 23:20:30 wb wb-init[2454]: Error: environment not initialized
Feb 04 23:20:31 wb wb-init[2454]: Cannot parse config file '/etc/fw_env.config': No such file or directory
Feb 04 23:20:31 wb wb-init[2454]: Error: environment not initialized
Feb 04 23:20:31 wb wb-init[2454]: .

Before fix:
Setting up wb-configs (1.79) ...
/var/lib/dpkg/info/wb-configs.postinst: line 10: FVER: command not found
cp: cannot stat '/usr/share/wb-configs/u-boot/default.': No such file or directory
*** OMINOUS WARNING ***: /etc/hostname is not linked to either hostname.wb or hostname.wb-orig
*** OMINOUS WARNING ***: /etc/network/interfaces is not linked to either interfaces.wb or interfaces.wb-orig
*** OMINOUS WARNING ***: /etc/dnsmasq.conf is not linked to either dnsmasq.conf.wb or dnsmasq.conf.wb-orig
*** OMINOUS WARNING ***: /etc/hostapd.conf is not linked to either hostapd.conf.wb or hostapd.conf.wb-orig
Setting up wb-hwconf-manager (1.26.0) ...

After fix:
aqualx@wb ~ $ sudo dpkg-reconfigure wb-configs
*** OMINOUS WARNING ***: /etc/hostname is not linked to either hostname.wb or hostname.wb-orig
*** OMINOUS WARNING ***: /etc/network/interfaces is not linked to either interfaces.wb or interfaces.wb-orig
*** OMINOUS WARNING ***: /etc/dnsmasq.conf is not linked to either dnsmasq.conf.wb or dnsmasq.conf.wb-orig
*** OMINOUS WARNING ***: /etc/hostapd.conf is not linked to either hostapd.conf.wb or hostapd.conf.wb-orig