### PR TITLE
.bashrc appending to $PYTHONPATH instead of rewriting it

### DIFF
--- a/configs/root/.bashrc.wb
+++ b/configs/root/.bashrc.wb
@@ -1,3 +1,3 @@
-export PYTHONPATH=/opt/quick2wire-python-api-master/
+export PYTHONPATH=$PYTHONPATH:/opt/quick2wire-python-api-master/
 . /etc/wb_env.sh
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-configs (1.81.1) stable; urgency=medium
+
+  * fixed $PYTHONPATH default erasing
+
+ -- Vladimir Romanov <v.romanov@contactless.ru>  Wed, 5 Feb 2020 12:11:34 +0300
+
 wb-configs (1.81.0) stable; urgency=medium
 
   * add udev rules to create /dev/i2c-modX symlinks


### PR DESCRIPTION
Применяется последним и затирает всё, что прописывали в /etc/profile.d/...